### PR TITLE
The one that removed eucarc.

### DIFF
--- a/TestSuites/AllTestsSuite.xml
+++ b/TestSuites/AllTestsSuite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Eutester4j Test Suite">
+<suite name="N4j Test Suite">
 
     <suite-files>
         <suite-file path="CloudWatchSuite.xml" />
@@ -13,7 +13,7 @@
 
     <test name="Eutester4j_Sanity_Test">
         <classes>
-            <class name="com.eucalyptus.tests.awssdk.Eutester4jTest"/>
+            <class name="com.eucalyptus.tests.awssdk.N4jTest"/>
         </classes>
     </test>
 </suite>

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--<project name="Eutester4J" basedir="." default="clean-build">-->
-<project name="Eutester4J" basedir="." default="clean-build" xmlns:ivy="antlib:org.apache.ivy.ant">
+<!--<project name="N4J" basedir="." default="clean-build">-->
+<project name="N4J" basedir="." default="clean-build" xmlns:ivy="antlib:org.apache.ivy.ant">
 
 	<!-- These properties' default values can be overridden on the ant command line, e.g: -->
 	<!-- ant clean-build -Deucarc=/my/path/to/eucarc -Dtests=CI-run.xml -->
@@ -9,8 +9,10 @@
     <property name="build.dir" value="build"/>
     <property name="classes.dir" value="${build.dir}/classes"/>
     <property name="deps.dir" value="dependencies"/>
-    <property name="testng.output.dir" value="eutester4j_results"/>
-    <property name="eucarc" value="eucarc"/>
+    <property name="testng.output.dir" value="n4j_results"/>
+    <property name="clcip" value="192.168.0.10"/>
+    <property name="user" value="root"/>
+    <property name="password" value="foobar"/>
     <property name="endpoints" value="endpoints.xml"/>
     <property name="tests" value="AllTestsSuite.xml"/>
     <property name="ivy.cache.ttl.default" value="1d"/>
@@ -73,7 +75,9 @@
         <mkdir dir="${testng.output.dir}"/>
         <testng outputdir="${testng.output.dir}" classpathref="classpath" haltonfailure="true">
             <xmlfileset dir="./TestSuites" includes="${tests}"/>
-            <jvmarg value="-Deucarc=${eucarc}" />
+            <jvmarg value="-Dclcip=${clcip}" />
+            <jvmarg value="-Duser=${user}" />
+            <jvmarg value="-Dpassword=${password}" />
             <jvmarg value="-Dcom.amazonaws.regions.RegionUtils.fileOverride=${endpoints}"/>
         </testng>
     </target>

--- a/com/eucalyptus/tests/awssdk/CloudCleaner.java
+++ b/com/eucalyptus/tests/awssdk/CloudCleaner.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  *

--- a/com/eucalyptus/tests/awssdk/CloudWatchDeleteMetricAlarmTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchDeleteMetricAlarmTest.java
@@ -7,8 +7,8 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.cw;
-import static com.eucalyptus.tests.awssdk.Eutester4j.getCloudInfo;
+import static com.eucalyptus.tests.awssdk.N4j.cw;
+import static com.eucalyptus.tests.awssdk.N4j.getCloudInfo;
 
 public class CloudWatchDeleteMetricAlarmTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmHistoryTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmHistoryTest.java
@@ -9,8 +9,8 @@ import org.testng.annotations.Test;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.cw;
-import static com.eucalyptus.tests.awssdk.Eutester4j.getCloudInfo;
+import static com.eucalyptus.tests.awssdk.N4j.cw;
+import static com.eucalyptus.tests.awssdk.N4j.getCloudInfo;
 
 public class CloudWatchDescribeAlarmHistoryTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmsForMetricTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmsForMetricTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchDescribeAlarmsForMetricTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmsTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchDescribeAlarmsTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchDescribeAlarmsTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchDisableAlarmActionsTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchDisableAlarmActionsTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchDisableAlarmActionsTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchEnableAlarmActionsTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchEnableAlarmActionsTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchEnableAlarmActionsTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchGetMetricStatisticsTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchGetMetricStatisticsTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchGetMetricStatisticsTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchListMetricsTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchListMetricsTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchListMetricsTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchPutMetricAlarmTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchPutMetricAlarmTest.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest;
 import com.amazonaws.services.cloudwatch.model.Statistic;
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchPutMetricAlarmTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchPutMetricDataTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchPutMetricDataTest.java
@@ -3,14 +3,13 @@ package com.eucalyptus.tests.awssdk;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.StatisticSet;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchPutMetricDataTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/CloudWatchStateChangeTest.java
+++ b/com/eucalyptus/tests/awssdk/CloudWatchStateChangeTest.java
@@ -4,7 +4,7 @@ import com.amazonaws.services.cloudwatch.model.SetAlarmStateRequest;
 import com.amazonaws.services.cloudwatch.model.StateValue;
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 public class CloudWatchStateChangeTest {
     @Test

--- a/com/eucalyptus/tests/awssdk/EUCA8948.java
+++ b/com/eucalyptus/tests/awssdk/EUCA8948.java
@@ -1,8 +1,8 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Map;
@@ -18,7 +18,6 @@ import com.amazonaws.services.identitymanagement.model.CreateRoleRequest;
 import com.amazonaws.services.identitymanagement.model.CreateRoleResult;
 import com.amazonaws.services.identitymanagement.model.PutRolePolicyRequest;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
@@ -53,36 +52,30 @@ public class EUCA8948 {
 		try {
 			account = this.getClass().getSimpleName().toLowerCase();
 
-			if (Eutester4j.eucarc != null) {
-				Eutester4j.CREDPATH = Eutester4j.eucarc;
-			} else {
-				Eutester4j.CREDPATH = "eucarc";
-			}
+			print("Getting cloud information from " + N4j.CREDPATH);
 
-			print("Getting cloud information from " + Eutester4j.CREDPATH);
+			N4j.IAM_ENDPOINT = N4j.getAttribute(N4j.CREDPATH, "iam-url");
+			N4j.TOKENS_ENDPOINT = N4j.getAttribute(N4j.CREDPATH, "sts-url");
+			N4j.S3_ENDPOINT = N4j.getAttribute(N4j.CREDPATH, "s3-url");
 
-			Eutester4j.IAM_ENDPOINT = Eutester4j.parseEucarc(Eutester4j.CREDPATH, "EUARE_URL");
-			Eutester4j.TOKENS_ENDPOINT = Eutester4j.parseEucarc(Eutester4j.CREDPATH, "TOKEN_URL");
-			Eutester4j.S3_ENDPOINT = Eutester4j.parseEucarc(Eutester4j.CREDPATH, "S3_URL");
+			N4j.ACCESS_KEY = N4j.getAttribute(N4j.CREDPATH, "key-id");
+			N4j.SECRET_KEY = N4j.getAttribute(N4j.CREDPATH, "secret-key");
 
-			Eutester4j.ACCESS_KEY = Eutester4j.parseEucarc(Eutester4j.CREDPATH, "EC2_ACCESS_KEY").replace("'", "");
-			Eutester4j.SECRET_KEY = Eutester4j.parseEucarc(Eutester4j.CREDPATH, "EC2_SECRET_KEY").replace("'", "");
-
-			Eutester4j.youAre = Eutester4j.getYouAreClient(Eutester4j.ACCESS_KEY, Eutester4j.SECRET_KEY, Eutester4j.IAM_ENDPOINT);
+			N4j.youAre = N4j.getYouAreClient(N4j.ACCESS_KEY, N4j.SECRET_KEY, N4j.IAM_ENDPOINT);
 
 			// Create a new account if one does not exist
 			try {
-				Eutester4j.createAccount(account);
+				N4j.createAccount(account);
 			} catch (Exception e) {
 				// Account may already exist, try getting the keys
 			}
-			Map<String, String> keyMap = Eutester4j.getUserKeys(account, "admin");
+			Map<String, String> keyMap = N4j.getUserKeys(account, "admin");
 
 			accessKey = keyMap.get("ak");
 			secretKey = keyMap.get("sk");
 
-			userYouAre = Eutester4j.getYouAreClient(accessKey, secretKey, Eutester4j.IAM_ENDPOINT);
-			eucalyptusSts = getSecurityTokenService(Eutester4j.ACCESS_KEY, Eutester4j.SECRET_KEY, Eutester4j.TOKENS_ENDPOINT);
+			userYouAre = N4j.getYouAreClient(accessKey, secretKey, N4j.IAM_ENDPOINT);
+			eucalyptusSts = getSecurityTokenService(N4j.ACCESS_KEY, N4j.SECRET_KEY, N4j.TOKENS_ENDPOINT);
 		} catch (Exception e) {
 			try {
 				teardown();
@@ -102,7 +95,7 @@ public class EUCA8948 {
 	@AfterClass
 	public void teardown() throws Exception {
 		print("*** POST SUITE CLEANUP ***");
-		Eutester4j.deleteAccount(account);
+		N4j.deleteAccount(account);
 	}
 
 	@Test
@@ -133,8 +126,8 @@ public class EUCA8948 {
 			print("Expires = " + roleCreds.getExpiration());
 
 			print(account + ": Initializing s3 client with the temporary credentials");
-			final AmazonS3 s3 = Eutester4j.getS3Client(new BasicSessionCredentials( roleCreds.getAccessKeyId( ), roleCreds.getSecretAccessKey( ),
-					roleCreds.getSessionToken( ) ), Eutester4j.S3_ENDPOINT );
+			final AmazonS3 s3 = N4j.getS3Client(new BasicSessionCredentials( roleCreds.getAccessKeyId( ), roleCreds.getSecretAccessKey( ),
+					roleCreds.getSessionToken( ) ), N4j.S3_ENDPOINT );
 			print("The owner of the account executing this call is " + s3.getS3AccountOwner());
 
 			print("Sleeping for " + (DURATION + 60) + " seconds to allow the credentials to expire");

--- a/com/eucalyptus/tests/awssdk/Eutester4jTemplateTest.java
+++ b/com/eucalyptus/tests/awssdk/Eutester4jTemplateTest.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/com/eucalyptus/tests/awssdk/Eutester4jTest.java
+++ b/com/eucalyptus/tests/awssdk/Eutester4jTest.java
@@ -1,7 +1,7 @@
 /**
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2009-2013, Eucalyptus Systems, Inc.
+ * Copyright (c) 2009-2016, Eucalyptus Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use of this software in source and binary forms, with or
@@ -48,7 +48,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * At this time eucarc path needs to be hard coded. 

--- a/com/eucalyptus/tests/awssdk/GetBucketInfo.java
+++ b/com/eucalyptus/tests/awssdk/GetBucketInfo.java
@@ -8,8 +8,8 @@ import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule;
 import com.amazonaws.services.s3.model.Grant;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3Client;
-import static com.eucalyptus.tests.awssdk.Eutester4j.s3;
+import static com.eucalyptus.tests.awssdk.N4j.initS3Client;
+import static com.eucalyptus.tests.awssdk.N4j.s3;
 
 
 public class GetBucketInfo {

--- a/com/eucalyptus/tests/awssdk/JCloudsTest.java
+++ b/com/eucalyptus/tests/awssdk/JCloudsTest.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.compute.domain.ComputeMetadata;

--- a/com/eucalyptus/tests/awssdk/N4jTest.java
+++ b/com/eucalyptus/tests/awssdk/N4jTest.java
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ ************************************************************************/
+
+package com.eucalyptus.tests.awssdk;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import static com.eucalyptus.tests.awssdk.N4j.*;
+
+
+public class N4jTest {
+    /**
+     * Called once before tests run
+     *
+     * @throws java.lang.Exception
+     */
+    @BeforeClass
+    public void setUpBeforeClass() throws Exception {
+        testInfo(this.getClass().getSimpleName());
+        getCloudInfo();
+    }
+
+
+    /**
+     * This test method ensures that we established connection to a cloud and have retrieved cloud admin credentials
+     *
+     */
+    @Test
+    public void proof() {
+        print("AK: " + ACCESS_KEY);
+        print("SK: " + SECRET_KEY);
+        print("ID: " + ACCOUNT_ID);
+        print("EC2 endpoint: " + EC2_ENDPOINT);
+    }
+
+    /**
+     * Called after all the tests in a class
+     *
+     * @throws java.lang.Exception
+     */
+    @AfterClass
+    public void tearDownAfterClass() throws Exception {
+        deleteTestCreds();
+    }
+}

--- a/com/eucalyptus/tests/awssdk/S3BucketACLTests.java
+++ b/com/eucalyptus/tests/awssdk/S3BucketACLTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -81,7 +81,7 @@ public class S3BucketACLTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3BucketTests.java
+++ b/com/eucalyptus/tests/awssdk/S3BucketTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ public class S3BucketTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3CopyObjectTests.java
+++ b/com/eucalyptus/tests/awssdk/S3CopyObjectTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -90,20 +90,20 @@ public class S3CopyObjectTests {
   public AmazonS3 getS3Client(String credPath) throws Exception {
     print("Getting cloud information from " + credPath);
 
-    String s3Endpoint = Eutester4j.parseEucarc(credPath, "S3_URL");
+    String s3Endpoint = N4j.getAttribute(credPath, "S3_URL");
 
-    String secretKey = Eutester4j.parseEucarc(credPath, "EC2_SECRET_KEY").replace("'", "");
-    String accessKey = Eutester4j.parseEucarc(credPath, "EC2_ACCESS_KEY").replace("'", "");
+    String secretKey = N4j.getAttribute(credPath, "EC2_SECRET_KEY").replace("'", "");
+    String accessKey = N4j.getAttribute(credPath, "EC2_ACCESS_KEY").replace("'", "");
 
     print("Initializing S3 connections");
-    return Eutester4j.getS3Client(accessKey, secretKey, s3Endpoint);
+    return N4j.getS3Client(accessKey, secretKey, s3Endpoint);
   }
 
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(accountA);
-    Eutester4j.deleteAccount(accountB);
+    N4j.deleteAccount(accountA);
+    N4j.deleteAccount(accountB);
     s3ClientA = null;
     s3ClientB = null;
   }

--- a/com/eucalyptus/tests/awssdk/S3CorsTests.java
+++ b/com/eucalyptus/tests/awssdk/S3CorsTests.java
@@ -1,22 +1,18 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
 
 //LPT The below import is only needed for running against Eucalyptus
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
 
 //LPT The below two imports are only needed for running against AWS
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3Client;
-import static com.eucalyptus.tests.awssdk.Eutester4j.s3;
 
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.testng.annotations.AfterClass;
@@ -27,24 +23,11 @@ import org.testng.annotations.Test;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AccessControlList;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
-import com.amazonaws.services.s3.model.BucketLoggingConfiguration;
-import com.amazonaws.services.s3.model.BucketTaggingConfiguration;
-import com.amazonaws.services.s3.model.BucketVersioningConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
 import com.amazonaws.services.s3.model.CORSRule.AllowedMethods;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.CanonicalGrantee;
-import com.amazonaws.services.s3.model.Grant;
-import com.amazonaws.services.s3.model.GroupGrantee;
 import com.amazonaws.services.s3.model.Owner;
-import com.amazonaws.services.s3.model.Permission;
-import com.amazonaws.services.s3.model.SetBucketLoggingConfigurationRequest;
-import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest;
-import com.amazonaws.services.s3.model.TagSet;
 
 /**
  * <p>
@@ -103,7 +86,7 @@ public class S3CorsTests {
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
     //LPT Don't do this with AWS, won't let you create an account via API
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3ListMpuTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ListMpuTests.java
@@ -62,14 +62,14 @@
 
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.IAM_ENDPOINT;
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.getUserKeys;
-import static com.eucalyptus.tests.awssdk.Eutester4j.getYouAreClient;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.IAM_ENDPOINT;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.getUserKeys;
+import static com.eucalyptus.tests.awssdk.N4j.getYouAreClient;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -147,19 +147,19 @@ public class S3ListMpuTests {
   public AmazonS3 getS3Client(String credPath) throws Exception {
     print("Getting cloud information from " + credPath);
 
-    String s3Endpoint = Eutester4j.parseEucarc(credPath, "S3_URL");
+    String s3Endpoint = N4j.getAttribute(credPath, "S3_URL");
 
-    String secretKey = Eutester4j.parseEucarc(credPath, "EC2_SECRET_KEY").replace("'", "");
-    String accessKey = Eutester4j.parseEucarc(credPath, "EC2_ACCESS_KEY").replace("'", "");
+    String secretKey = N4j.getAttribute(credPath, "EC2_SECRET_KEY").replace("'", "");
+    String accessKey = N4j.getAttribute(credPath, "EC2_ACCESS_KEY").replace("'", "");
 
     print("Initializing S3 connections");
-    return Eutester4j.getS3Client(accessKey, secretKey, s3Endpoint);
+    return N4j.getS3Client(accessKey, secretKey, s3Endpoint);
   }
 
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(accountA);
+    N4j.deleteAccount(accountA);
     s3ClientA = null;
   }
 
@@ -583,8 +583,8 @@ public class S3ListMpuTests {
       printException(ase);
       assertThat(false, "Failed to run listUploadsMultipleAccounts");
     } finally {
-      Eutester4j.deleteAccount(accountB);
-      Eutester4j.deleteAccount(accountC);
+      N4j.deleteAccount(accountB);
+      N4j.deleteAccount(accountC);
       s3ClientB = null;
       s3ClientC = null;
     }

--- a/com/eucalyptus/tests/awssdk/S3ListObjectsTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ListObjectsTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -95,7 +95,7 @@ public class S3ListObjectsTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3ListVersionsTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ListVersionsTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -93,7 +93,7 @@ public class S3ListVersionsTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 
@@ -1413,7 +1413,7 @@ public class S3ListVersionsTests {
       printException(ase);
       assertThat(false, "Failed to run listVersionsDifferentAccount");
     } finally {
-      Eutester4j.deleteAccount(accountB);
+      N4j.deleteAccount(accountB);
       s3ClientB = null;
     }
   }
@@ -1465,7 +1465,7 @@ public class S3ListVersionsTests {
       printException(ase);
       assertThat(false, "Failed to run deleteVersionNonBucketOwnerAccount");
     } finally {
-      Eutester4j.deleteAccount(accountC);
+      N4j.deleteAccount(accountC);
       s3ClientC = null;
     }
   }
@@ -1473,13 +1473,13 @@ public class S3ListVersionsTests {
   private AmazonS3 getS3Client(String credPath) throws Exception {
     print("Getting cloud information from " + credPath);
 
-    String s3Endpoint = Eutester4j.parseEucarc(credPath, "S3_URL") + "/";
+    String s3Endpoint = N4j.getAttribute(credPath, "S3_URL") + "/";
 
-    String secretKey = Eutester4j.parseEucarc(credPath, "EC2_SECRET_KEY").replace("'", "");
-    String accessKey = Eutester4j.parseEucarc(credPath, "EC2_ACCESS_KEY").replace("'", "");
+    String secretKey = N4j.getAttribute(credPath, "EC2_SECRET_KEY").replace("'", "");
+    String accessKey = N4j.getAttribute(credPath, "EC2_ACCESS_KEY").replace("'", "");
 
     print("Initializing S3 connections");
-    return Eutester4j.getS3Client(accessKey, secretKey, s3Endpoint);
+    return N4j.getS3Client(accessKey, secretKey, s3Endpoint);
   }
 
   // @Test

--- a/com/eucalyptus/tests/awssdk/S3MultiPartUploadTests.java
+++ b/com/eucalyptus/tests/awssdk/S3MultiPartUploadTests.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,11 +62,11 @@
 
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.BufferedInputStream;
@@ -165,19 +165,19 @@ public class S3MultiPartUploadTests {
   public AmazonS3 getS3Client(String credPath) throws Exception {
     print("Getting cloud information from " + credPath);
 
-    String s3Endpoint = Eutester4j.parseEucarc(credPath, "S3_URL");
+    String s3Endpoint = N4j.getAttribute(credPath, "S3_URL");
 
-    String secretKey = Eutester4j.parseEucarc(credPath, "EC2_SECRET_KEY").replace("'", "");
-    String accessKey = Eutester4j.parseEucarc(credPath, "EC2_ACCESS_KEY").replace("'", "");
+    String secretKey = N4j.getAttribute(credPath, "EC2_SECRET_KEY").replace("'", "");
+    String accessKey = N4j.getAttribute(credPath, "EC2_ACCESS_KEY").replace("'", "");
 
     print("Initializing S3 connections");
-    return Eutester4j.getS3Client(accessKey, secretKey, s3Endpoint);
+    return N4j.getS3Client(accessKey, secretKey, s3Endpoint);
   }
 
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 
@@ -1141,8 +1141,8 @@ public class S3MultiPartUploadTests {
       printException(ase);
       assertThat(false, "Failed to run mpuTasksDifferentAccount");
     } finally {
-      Eutester4j.deleteAccount(accountB);
-      Eutester4j.deleteAccount(accountC);
+      N4j.deleteAccount(accountB);
+      N4j.deleteAccount(accountC);
       s3ClientB = null;
       s3ClientC = null;
     }

--- a/com/eucalyptus/tests/awssdk/S3ObjectACLAcrossAccountsTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ObjectACLAcrossAccountsTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -91,8 +91,8 @@ public class S3ObjectACLAcrossAccountsTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(accountA);
-    Eutester4j.deleteAccount(accountB);
+    N4j.deleteAccount(accountA);
+    N4j.deleteAccount(accountB);
     s3ClientA = null;
     s3ClientB = null;
   }

--- a/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -113,7 +113,7 @@ public class S3ObjectACLTests {
         print("Unable to run clean up task: " + e);
       }
     }
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3ObjectLifecycleTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ObjectLifecycleTests.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,11 +62,11 @@
 
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
@@ -119,7 +119,7 @@ public class S3ObjectLifecycleTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3ObjectMultiDeleteTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ObjectMultiDeleteTests.java
@@ -1,9 +1,9 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
@@ -97,8 +97,8 @@ public class S3ObjectMultiDeleteTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(accountA);
-    Eutester4j.deleteAccount(accountB);
+    N4j.deleteAccount(accountA);
+    N4j.deleteAccount(accountB);
     s3ClientA = null;
     s3ClientB = null;
   }

--- a/com/eucalyptus/tests/awssdk/S3ObjectTests.java
+++ b/com/eucalyptus/tests/awssdk/S3ObjectTests.java
@@ -1,10 +1,10 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.eucaUUID;
-import static com.eucalyptus.tests.awssdk.Eutester4j.initS3ClientWithNewAccount;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
-import static com.eucalyptus.tests.awssdk.Eutester4j.testInfo;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID;
+import static com.eucalyptus.tests.awssdk.N4j.initS3ClientWithNewAccount;
+import static com.eucalyptus.tests.awssdk.N4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.testInfo;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.BufferedReader;
@@ -70,7 +70,7 @@ public class S3ObjectTests {
   @AfterClass
   public void teardown() throws Exception {
     print("### POST SUITE CLEANUP - " + this.getClass().getSimpleName());
-    Eutester4j.deleteAccount(account);
+    N4j.deleteAccount(account);
     s3 = null;
   }
 

--- a/com/eucalyptus/tests/awssdk/S3Utils.java
+++ b/com/eucalyptus/tests/awssdk/S3Utils.java
@@ -1,7 +1,7 @@
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.assertThat;
-import static com.eucalyptus.tests.awssdk.Eutester4j.print;
+import static com.eucalyptus.tests.awssdk.N4j.assertThat;
+import static com.eucalyptus.tests.awssdk.N4j.print;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Iterator;

--- a/com/eucalyptus/tests/awssdk/TestAdminRoles.java
+++ b/com/eucalyptus/tests/awssdk/TestAdminRoles.java
@@ -1,5 +1,5 @@
 /*************************************************************************
-* Copyright 2009-2013 Eucalyptus Systems, Inc.
+* Copyright 2009-2016 Eucalyptus Systems, Inc.
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.github.sjones4.youcan.youare.model.Account;
 import org.testng.annotations.Test;
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingActivities.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingActivities.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests auto scaling activities.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingAdministration.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingAdministration.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests auto scaling administrative extensions.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingAvailabilityZoneRebalancing.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingAvailabilityZoneRebalancing.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests rebalancing when availability zones are updated.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingCooldown.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingCooldown.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests cooldown for changing group desired capacity

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeGroupsInstances.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeGroupsInstances.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests the inclusion of instance data when describing groups

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeInstances.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeInstances.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests launching and describing instances with auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingDescribePolicyAlarms.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingDescribePolicyAlarms.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests listing CloudWatch alarms associated with auto scaling policies.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeTags.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeTags.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests filtering for auto scaling tags.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingEC2InstanceTerminationProtection.groovy
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingEC2InstanceTerminationProtection.groovy
@@ -22,10 +22,10 @@ import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 
 /**
@@ -46,7 +46,7 @@ class TestAutoScalingEC2InstanceTerminationProtection {
 
   public TestAutoScalingEC2InstanceTerminationProtection( ){
     minimalInit( )
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingEC2ReferenceValidation.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingEC2ReferenceValidation.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests reference validation for launch configurations and

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
@@ -28,10 +28,10 @@ import com.amazonaws.services.ec2.model.Filter
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests Auto Scaling use of EC2 VPC functionality.
@@ -52,7 +52,7 @@ class TestAutoscalingEC2VPC {
 
   public TestAutoscalingEC2VPC() {
     minimalInit()
-    this.host = HOST_IP;
+    this.host = CLC_IP;
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingELBAddRemoveInstances.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingELBAddRemoveInstances.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingELBInstanceHealthMonitoring.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingELBInstanceHealthMonitoring.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingELBReferenceValidation.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingELBReferenceValidation.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests reference validation for auto scaling groups with ELB.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingEc2InstanceHealthMonitoring.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingEc2InstanceHealthMonitoring.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests EC2 monitoring of instance health for auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingInstanceLifecycle.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingInstanceLifecycle.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  *

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingInstanceProfile.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingInstanceProfile.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingLaunchAndTerminate.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingLaunchAndTerminate.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests launching and terminating instances with auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsManagement.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsManagement.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsSubmission.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsSubmission.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests submitting auto scaling metrics to CloudWatch.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingMultipleAvailabilityZones.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingMultipleAvailabilityZones.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests auto scaling with multiple availability zones.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingSetInstanceHealth.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingSetInstanceHealth.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests manually setting instance health for auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingSuspendAndResumeProcesses.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingSuspendAndResumeProcesses.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingTags.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingTags.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests tags for auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingTerminateInstances.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingTerminateInstances.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests manually terminating instances with auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingUnsupportedOptions.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingUnsupportedOptions.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests unsupported options for auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingVMTypeReferenceValidation.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingVMTypeReferenceValidation.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests reference validation for VM types.

--- a/com/eucalyptus/tests/awssdk/TestAutoScalingValidation.java
+++ b/com/eucalyptus/tests/awssdk/TestAutoScalingValidation.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests parameter validation for auto scaling.

--- a/com/eucalyptus/tests/awssdk/TestCFAdministration.groovy
+++ b/com/eucalyptus/tests/awssdk/TestCFAdministration.groovy
@@ -26,10 +26,10 @@ import com.github.sjones4.youcan.youare.YouAreClient
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * This application tests administration for CF resources.
@@ -49,7 +49,7 @@ class TestCFAdministration {
 
   public TestCFAdministration( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -89,7 +89,7 @@ class TestCFAdministration {
 
     final List<Runnable> cleanupTasks = [] as List<Runnable>
     try {
-      final String userName = "${namePrefix}cf-test-user"
+      final String userName = "${namePrefix}cf-test-USER"
       AWSCredentialsProvider cfAccountCredentials = null
       AWSCredentialsProvider cfUserCredentials = null
       final YouAre youAre = getYouAreClient( credentials )
@@ -123,22 +123,22 @@ class TestCFAdministration {
           assertThat( cfAccountCredentials != null, "Expected admin credentials" )
           print( "Created cf account access key: ${cfAccountCredentials.credentials.AWSAccessKeyId}" )
 
-          print( "Creating user in admin account for policy testing: ${userName}" )
+          print( "Creating USER in admin account for policy testing: ${userName}" )
           final String userId = createUser( new CreateUserRequest( userName: userName, path: '/' ) ).with {
             user.userId
           }
-          assertThat( userId != null, "Expected user ID" )
-          print( "Created admin user with number: ${userId}" )
+          assertThat( userId != null, "Expected USER ID" )
+          print( "Created admin USER with number: ${userId}" )
 
-          print( "Creating access key for admin user: ${userName}" )
+          print( "Creating access key for admin USER: ${userName}" )
           cfUserCredentials = createAccessKey( new CreateAccessKeyRequest( userName: userName ) ).with {
             accessKey?.with {
               new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
             }
           }
 
-          assertThat( cfUserCredentials != null, "Expected user credentials" )
-          print( "Created cf user access key: ${cfAccountCredentials.credentials.AWSAccessKeyId}" )
+          assertThat( cfUserCredentials != null, "Expected USER credentials" )
+          print( "Created cf USER access key: ${cfAccountCredentials.credentials.AWSAccessKeyId}" )
 
           void
         }
@@ -283,43 +283,43 @@ class TestCFAdministration {
       }
 
       getCloudFormationClient( cfUserCredentials ).with {
-        println( "Verifying user sees permitted stack when describing" )
+        println( "Verifying USER sees permitted stack when describing" )
         describeStacks( ).with {
           assertThat( 1 == stacks?.size(), "Expected 1 stack" )
         }
 
-        println( "Verifying user sees permitted stack when describing by name" )
+        println( "Verifying USER sees permitted stack when describing by name" )
         describeStacks( new DescribeStacksRequest( stackName: stackName1 ) ).with {
           assertThat( 1 == stacks?.size(), "Expected 1 stack" )
         }
 
-        println( "Verifying user sees permitted stack when listing" )
+        println( "Verifying USER sees permitted stack when listing" )
         listStacks( ).with {
           assertThat( 1 == stackSummaries?.size(), "Expected 1 stack" )
         }
 
-        println( "Verifying user can describe stack events" )
+        println( "Verifying USER can describe stack events" )
         describeStackEvents( new DescribeStackEventsRequest(
                 stackName: stackName1
         ) ).with {
           assertThat( !stackEvents?.empty, "Expected stack events" )
         }
 
-        println( "Verifying user can describe stack resources" )
+        println( "Verifying USER can describe stack resources" )
         describeStackResources( new DescribeStackResourcesRequest(
                 stackName: stackName1
         ) ).with {
           assertThat( !stackResources?.empty, "Expected stack resources" )
         }
 
-        println( "Verifying user can list stack resources" )
+        println( "Verifying USER can list stack resources" )
         listStackResources( new ListStackResourcesRequest(
                 stackName: stackName1
         ) ).with {
           assertThat( !stackResourceSummaries?.empty, "Expected stack resources" )
         }
 
-        println( "Verifying user can delete stack ${stackName1}" )
+        println( "Verifying USER can delete stack ${stackName1}" )
         deleteStack( new DeleteStackRequest( stackName: stackName1 ) )
 
         print( "Waiting for stack ${stackName1} deletion" )

--- a/com/eucalyptus/tests/awssdk/TestCannedRoles.java
+++ b/com/eucalyptus/tests/awssdk/TestCannedRoles.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,8 +53,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
-import static com.eucalyptus.tests.awssdk.Eutester4j.youAre;
+import static com.eucalyptus.tests.awssdk.N4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.youAre;
 
 /**
  * This test verifies the functionality of https://eucalyptus.atlassian.net/browse/EUCA-8156, EUCA-8157, and EUCA-8158

--- a/com/eucalyptus/tests/awssdk/TestEC2DescribeInstanceStatus.java
+++ b/com/eucalyptus/tests/awssdk/TestEC2DescribeInstanceStatus.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 
 package com.eucalyptus.tests.awssdk;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/com/eucalyptus/tests/awssdk/TestEC2InstanceProfile.java
+++ b/com/eucalyptus/tests/awssdk/TestEC2InstanceProfile.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application test the EC2 RunInstances operation with instance profiles.

--- a/com/eucalyptus/tests/awssdk/TestEC2InstanceTerminationProtection.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2InstanceTerminationProtection.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
+import static N4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
+import static N4j.CLC_IP
 
 /**
  * This application tests EC2 instance termination protection.
@@ -32,7 +32,7 @@ class TestEC2InstanceTerminationProtection {
 
   public TestEC2InstanceTerminationProtection( ){
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestEC2RunInstancesClientToken.java
+++ b/com/eucalyptus/tests/awssdk/TestEC2RunInstancesClientToken.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests RunInstances with a client token.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCAssociationManagement.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCAssociationManagement.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.EC2_ENDPOINT;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * This application tests management of resource associations for EC2 VPC.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCAttributeManagement.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCAttributeManagement.groovy
@@ -12,10 +12,10 @@ import com.amazonaws.util.TimingInfo
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests management of attributes EC2 VPC.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCDefaultVPC.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCDefaultVPC.groovy
@@ -17,11 +17,11 @@ import com.github.sjones4.youcan.youprop.model.ModifyPropertyValueRequest
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.EC2_ENDPOINT;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * This application tests EC2 VPC default VPC.
@@ -41,7 +41,7 @@ class TestEC2VPCDefaultVPC {
 
   public TestEC2VPCDefaultVPC(){
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCDnsNames.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCDnsNames.groovy
@@ -8,10 +8,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests DNS names for EC2 VPC instances / enis.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCElasticIPs.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCElasticIPs.groovy
@@ -9,11 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests EC2 VPC elastic IP functionality.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCFilteringNonVPCResources.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCFilteringNonVPCResources.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests VPC filtering for non-VPC specific EC2 resources.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCManagement.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCManagement.groovy
@@ -32,7 +32,7 @@ import com.amazonaws.services.ec2.model.DhcpConfiguration
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCModifyInstanceSecurityGroups.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCModifyInstanceSecurityGroups.groovy
@@ -8,10 +8,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests modification of instance security groups in EC2 VPC.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCNATGatewayManagement.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCNATGatewayManagement.groovy
@@ -10,7 +10,7 @@ import com.amazonaws.services.ec2.model.*
 import org.testng.Assert
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*
+import static N4j.*
 
 /**
  * This application tests EC2 VPC NAT gateway management

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkAclEntryManagement.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkAclEntryManagement.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests management of network ACL entries for EC2 VPC.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkInterfaceAttach.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkInterfaceAttach.groovy
@@ -10,10 +10,10 @@ import com.amazonaws.services.ec2.model.*
 import org.testng.Assert
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+import static N4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
 
 /**
  * This application tests EC2 VPC network interface attach/detach functionality.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkInterfaces.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCNetworkInterfaces.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.minimalInit
 
 /**
  * This application tests EC2 VPC network interface functionality.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCQuotasLimits.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCQuotasLimits.groovy
@@ -21,11 +21,11 @@ import com.github.sjones4.youcan.youprop.model.ModifyPropertyValueRequest
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests quotas and limits for EC2 VPC resources.
@@ -45,7 +45,7 @@ class TestEC2VPCQuotasLimits {
 
   public TestEC2VPCQuotasLimits() {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCResourceConditionPolicy.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCResourceConditionPolicy.groovy
@@ -18,11 +18,11 @@ import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests IAM policy for EC2 VPC resource conditions.
@@ -42,7 +42,7 @@ class TestEC2VPCResourceConditionPolicy {
 
   public TestEC2VPCResourceConditionPolicy() {
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -118,7 +118,7 @@ class TestEC2VPCResourceConditionPolicy {
         print("Created vpc account access key: ${vpcAccountCredentials.credentials.AWSAccessKeyId}")
       }
 
-      print( "Creating 'permitted' test user in vpc account ${accountName}" )
+      print( "Creating 'permitted' test USER in vpc account ${accountName}" )
       getYouAreClient( vpcAccountCredentials ).with {
         createUser( new CreateUserRequest(
           path: '/',
@@ -131,7 +131,7 @@ class TestEC2VPCResourceConditionPolicy {
           }
         }
         assertThat( vpcPermCredentials != null, "Expected credentials" )
-        print( "Created vpc user access key: ${vpcPermCredentials.credentials.AWSAccessKeyId}" )
+        print( "Created vpc USER access key: ${vpcPermCredentials.credentials.AWSAccessKeyId}" )
         void
       }
 
@@ -158,7 +158,7 @@ class TestEC2VPCResourceConditionPolicy {
 
       }
 
-      print( "Creating 'denied' test user in vpc account ${accountName}" )
+      print( "Creating 'denied' test USER in vpc account ${accountName}" )
       getYouAreClient( vpcAccountCredentials ).with {
         createUser( new CreateUserRequest(
             path: '/',
@@ -171,7 +171,7 @@ class TestEC2VPCResourceConditionPolicy {
           }
         }
         assertThat( vpcDenyCredentials != null, "Expected credentials" )
-        print( "Created vpc user access key: ${vpcDenyCredentials.credentials.AWSAccessKeyId}" )
+        print( "Created vpc USER access key: ${vpcDenyCredentials.credentials.AWSAccessKeyId}" )
         void
       }
 
@@ -214,7 +214,7 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getYouAreClient( vpcAccountCredentials ).with {
-          print( "Adding policy for allow user" )
+          print( "Adding policy for allow USER" )
           putUserPolicy( new PutUserPolicyRequest(
               userName: 'permitted',
               policyName: 'allow',
@@ -261,7 +261,7 @@ class TestEC2VPCResourceConditionPolicy {
               """.stripIndent()
           ) )
 
-          print( "Adding policy for deny user" )
+          print( "Adding policy for deny USER" )
           putUserPolicy( new PutUserPolicyRequest(
               userName: 'denied',
               policyName: 'deny',
@@ -321,7 +321,7 @@ class TestEC2VPCResourceConditionPolicy {
         print( "Created security group ${securityGroupName} with identifier ${groupId}" )
 
         getEC2Client( vpcPermCredentials ).with {
-          print( "Authorizing egress with allow user" )
+          print( "Authorizing egress with allow USER" )
           authorizeSecurityGroupEgress( new AuthorizeSecurityGroupEgressRequest(
               groupId: groupId,
               ipPermissions: [
@@ -332,7 +332,7 @@ class TestEC2VPCResourceConditionPolicy {
               ]
           ) )
 
-          print( "Authorizing ingress with allow user" )
+          print( "Authorizing ingress with allow USER" )
           authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
               groupId: groupId,
               ipPermissions: [
@@ -345,7 +345,7 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcDenyCredentials ).with {
-          print( "Authorizing egress with deny user" )
+          print( "Authorizing egress with deny USER" )
           try {
             authorizeSecurityGroupEgress( new AuthorizeSecurityGroupEgressRequest(
                 groupId: groupId,
@@ -356,12 +356,12 @@ class TestEC2VPCResourceConditionPolicy {
                     )
                 ]
             ) )
-            assertThat( false, "Expected authorize egress failure for user without permission in vpc")
+            assertThat( false, "Expected authorize egress failure for USER without permission in vpc")
           } catch( Exception e ) {
             print( "Expected failure for authorize egress denied ${e}" )
           }
 
-          print( "Authorizing ingress with deny user" )
+          print( "Authorizing ingress with deny USER" )
           try {
             authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
                 groupId: groupId,
@@ -372,12 +372,12 @@ class TestEC2VPCResourceConditionPolicy {
                     )
                 ]
             ) )
-            assertThat( false, "Expected authorize ingress failure for user without permission in vpc")
+            assertThat( false, "Expected authorize ingress failure for USER without permission in vpc")
           } catch( Exception e ) {
             print( "Expected failure for authorize ingress denied ${e}" )
           }
 
-          print( "Revoking egress with deny user" )
+          print( "Revoking egress with deny USER" )
           try {
             revokeSecurityGroupEgress( new RevokeSecurityGroupEgressRequest(
                 groupId: groupId,
@@ -388,12 +388,12 @@ class TestEC2VPCResourceConditionPolicy {
                     )
                 ]
             ) )
-            assertThat( false, "Expected revoke egress failure for user without permission in vpc")
+            assertThat( false, "Expected revoke egress failure for USER without permission in vpc")
           } catch( Exception e ) {
             print( "Expected failure for revoke egress denied ${e}" )
           }
 
-          print( "Revoking ingress with deny user" )
+          print( "Revoking ingress with deny USER" )
           try {
             revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
                 groupId: groupId,
@@ -404,7 +404,7 @@ class TestEC2VPCResourceConditionPolicy {
                     )
                 ]
             ) )
-            assertThat( false, "Expected revoke ingress failure for user without permission in vpc")
+            assertThat( false, "Expected revoke ingress failure for USER without permission in vpc")
           } catch( Exception e ) {
             print( "Expected failure for revoke ingress denied ${e}" )
           }
@@ -413,7 +413,7 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcPermCredentials ).with {
-          print( "Revoking egress with allow user" )
+          print( "Revoking egress with allow USER" )
           revokeSecurityGroupEgress( new RevokeSecurityGroupEgressRequest(
               groupId: groupId,
               ipPermissions: [
@@ -424,7 +424,7 @@ class TestEC2VPCResourceConditionPolicy {
               ]
           ) )
 
-          print( "Revoking ingress with allow user" )
+          print( "Revoking ingress with allow USER" )
           revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
               groupId: groupId,
               ipPermissions: [
@@ -436,11 +436,11 @@ class TestEC2VPCResourceConditionPolicy {
           ) )
         }
 
-        print( "Deleting security group with deny user" )
+        print( "Deleting security group with deny USER" )
         getEC2Client( vpcDenyCredentials ).with {
           try {
             deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: groupId ) )
-            assertThat( false, "Expected delete failure for user without permission to delete security group resource in vpc")
+            assertThat( false, "Expected delete failure for USER without permission to delete security group resource in vpc")
           } catch( Exception e ) {
             print( "Expected failure for security group delete denied ${e}" )
           }
@@ -448,7 +448,7 @@ class TestEC2VPCResourceConditionPolicy {
           void
         }
 
-        print( "Deleting security group with allow user" )
+        print( "Deleting security group with allow USER" )
         getEC2Client( vpcPermCredentials ).with {
           deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: groupId ) )
         }
@@ -474,24 +474,24 @@ class TestEC2VPCResourceConditionPolicy {
         ) )
 
         getEC2Client( vpcDenyCredentials ).with {
-          print( "Deleting network acl entry with deny user" )
+          print( "Deleting network acl entry with deny USER" )
           try {
             deleteNetworkAclEntry( new DeleteNetworkAclEntryRequest(
                 networkAclId: networkAclId,
                 ruleNumber: 200,
                 egress: false
             ) )
-            assertThat( false, "Expected delete failure for user without permission to delete network acl entry resource in vpc")
+            assertThat( false, "Expected delete failure for USER without permission to delete network acl entry resource in vpc")
           } catch( Exception e ) {
             print( "Expected failure for network acl entry delete denied ${e}" )
           }
 
-          print( "Deleting network acl with deny user" )
+          print( "Deleting network acl with deny USER" )
           try {
             deleteNetworkAcl( new DeleteNetworkAclRequest(
                 networkAclId: networkAclId
             ) )
-            assertThat( false, "Expected delete failure for user without permission to delete network acl resource in vpc")
+            assertThat( false, "Expected delete failure for USER without permission to delete network acl resource in vpc")
           } catch( Exception e ) {
             print( "Expected failure for network acl delete denied ${e}" )
           }
@@ -500,14 +500,14 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcPermCredentials ).with {
-          print( "Deleting network acl entry with allow user" )
+          print( "Deleting network acl entry with allow USER" )
           deleteNetworkAclEntry( new DeleteNetworkAclEntryRequest(
               networkAclId: networkAclId,
               ruleNumber: 200,
               egress: false
           ) )
 
-          print( "Deleting network acl with allow user" )
+          print( "Deleting network acl with allow USER" )
           deleteNetworkAcl( new DeleteNetworkAclRequest(
               networkAclId: networkAclId
           ) )
@@ -533,23 +533,23 @@ class TestEC2VPCResourceConditionPolicy {
         ) )
 
         getEC2Client( vpcDenyCredentials ).with {
-          print( "Deleting route with deny user" )
+          print( "Deleting route with deny USER" )
           try {
             deleteRoute( new DeleteRouteRequest(
                 routeTableId: routeTableId,
                 destinationCidrBlock: '0.0.0.0/0',
             ) )
-            assertThat( false, "Expected delete failure for user without permission to delete route resource in vpc")
+            assertThat( false, "Expected delete failure for USER without permission to delete route resource in vpc")
           } catch( Exception e ) {
             print( "Expected failure for route delete denied ${e}" )
           }
 
-          print( "Deleting route table with deny user" )
+          print( "Deleting route table with deny USER" )
           try {
             deleteRouteTable( new DeleteRouteTableRequest(
                 routeTableId: routeTableId
             ) )
-            assertThat( false, "Expected delete failure for user without permission to delete route table resource in vpc")
+            assertThat( false, "Expected delete failure for USER without permission to delete route table resource in vpc")
           } catch( Exception e ) {
             print( "Expected failure for route table delete denied ${e}" )
           }
@@ -558,13 +558,13 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcPermCredentials ).with {
-          print( "Deleting route with allow user" )
+          print( "Deleting route with allow USER" )
           deleteRoute( new DeleteRouteRequest(
               routeTableId: routeTableId,
               destinationCidrBlock: '0.0.0.0/0',
           ) )
 
-          print( "Deleting route table with allow user" )
+          print( "Deleting route table with allow USER" )
           deleteRouteTable( new DeleteRouteTableRequest(
               routeTableId: routeTableId
           ) )
@@ -573,7 +573,7 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcDenyCredentials ).with {
-          print("Running instance with deny user")
+          print("Running instance with deny USER")
           try {
             String instanceId = runInstances(new RunInstancesRequest(
                 minCount: 1,
@@ -611,7 +611,7 @@ class TestEC2VPCResourceConditionPolicy {
                 }
               }
             }
-            assertThat( false, "Expected run instances failure for user without permission to run instance resources in subnet")
+            assertThat( false, "Expected run instances failure for USER without permission to run instance resources in subnet")
           } catch ( Exception e )  {
             print( "Expected failure for run instances denied ${e}" )
           }
@@ -620,7 +620,7 @@ class TestEC2VPCResourceConditionPolicy {
         }
 
         getEC2Client( vpcPermCredentials ).with {
-          print("Running instance with allow user")
+          print("Running instance with allow USER")
           String instanceId = runInstances(new RunInstancesRequest(
               minCount: 1,
               maxCount: 1,

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCRoutes.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCRoutes.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 import org.testng.Assert
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
+import static N4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
+import static N4j.EC2_ENDPOINT
 
 /**
  * This application tests EC2 VPC route functionality.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCRunInstanceNetworkInterfaces.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCRunInstanceNetworkInterfaces.groovy
@@ -10,10 +10,10 @@ import com.amazonaws.services.ec2.model.*
 import org.testng.Assert
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+import static N4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
 
 /**
  * This application tests EC2 VPC run instance with multiple network interfaces.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupEgressRules.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupEgressRules.groovy
@@ -10,10 +10,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 
 /**
@@ -35,7 +35,7 @@ class TestEC2VPCSecurityGroupEgressRules {
 
     public TestEC2VPCSecurityGroupEgressRules() {
         minimalInit()
-        this.host= HOST_IP
+        this.host= CLC_IP
         this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
     }
 

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroups.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroups.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 
 /**
@@ -35,7 +35,7 @@ class TestEC2VPCSecurityGroups {
 
     public TestEC2VPCSecurityGroups() {
         minimalInit()
-        this.host=HOST_IP
+        this.host=CLC_IP
         this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
     }
 
@@ -112,8 +112,8 @@ class TestEC2VPCSecurityGroups {
                             assertThat(userIdGroupPairs != null && userIdGroupPairs.size() == 1, "Expected one source group, but was: ${userIdGroupPairs?.size()}")
                             assertThat(ipRanges == null || ipRanges.isEmpty(), "Expected no ip ranges, but was: ${ipRanges?.size()}")
                             userIdGroupPairs[0].with {
-                                assertThat(expectedUserId == userId, "Expected user ${expectedUserId}, but was: ${userId}")
-                                assertThat(defaultSecurityGroupId == groupId, "Expected user ${defaultSecurityGroupId}, but was: ${groupId}")
+                                assertThat(expectedUserId == userId, "Expected USER ${expectedUserId}, but was: ${userId}")
+                                assertThat(defaultSecurityGroupId == groupId, "Expected USER ${defaultSecurityGroupId}, but was: ${groupId}")
                             }
                         }
                     }

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupsInstancesAttributes.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupsInstancesAttributes.groovy
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,10 +30,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests EC2 VPC security group functionality.
@@ -57,7 +57,7 @@ class TestEC2VPCSecurityGroupsInstancesAttributes {
 
   public TestEC2VPCSecurityGroupsInstancesAttributes() {
       minimalInit()
-      this.host=HOST_IP
+      this.host=CLC_IP
       this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
       this.imageOwners = imageOwners
   }

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCStartStop.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCStartStop.groovy
@@ -8,10 +8,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests VPC start/stop for ebs instances in a VPC.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCSubnetAvailableAddresses.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCSubnetAvailableAddresses.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests EC2 VPC subnet free address tracking.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCTaggingFiltering.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCTaggingFiltering.groovy
@@ -8,7 +8,7 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*
+import static N4j.*
 
 /**
  * This application tests tagging and filtering for EC2 VPC resources.

--- a/com/eucalyptus/tests/awssdk/TestEC2VPCValidation.groovy
+++ b/com/eucalyptus/tests/awssdk/TestEC2VPCValidation.groovy
@@ -9,10 +9,10 @@ import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.EC2_ENDPOINT
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.EC2_ENDPOINT
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests request message validation for EC2 VPC.

--- a/com/eucalyptus/tests/awssdk/TestELBAttributes.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBAttributes.groovy
@@ -21,10 +21,10 @@ import com.amazonaws.services.elasticloadbalancing.model.ModifyLoadBalancerAttri
 
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.CLC_IP;
+import static N4j.minimalInit;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  *
@@ -40,7 +40,7 @@ class TestELBAttributes {
 
   public TestELBAttributes(){
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestELBDefaultVPC.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBDefaultVPC.groovy
@@ -25,10 +25,10 @@ import com.amazonaws.services.elasticloadbalancing.model.EnableAvailabilityZones
 import com.amazonaws.services.elasticloadbalancing.model.Listener
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  *
@@ -44,7 +44,7 @@ class TestELBDefaultVPC {
 
   public TestELBDefaultVPC() {
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestELBEC2Classic.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBEC2Classic.groovy
@@ -24,10 +24,10 @@ import com.amazonaws.services.elasticloadbalancing.model.*
 import java.nio.charset.StandardCharsets
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  *
@@ -43,7 +43,7 @@ class TestELBEC2Classic {
 
   public TestELBEC2Classic( ) {
     minimalInit()
-    this.host=HOST_IP
+    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestELBIAMResource.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBIAMResource.groovy
@@ -23,10 +23,10 @@ import com.amazonaws.services.identitymanagement.model.GetUserPolicyRequest
 import com.amazonaws.services.identitymanagement.model.PutUserPolicyRequest
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  * This application tests IAM policy resource ARNs for ELB load balancers.
@@ -46,7 +46,7 @@ class TestELBIAMResource {
 
   public TestELBIAMResource() {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -117,21 +117,21 @@ class TestELBIAMResource {
         print( "Detected account number: ${accountNumber}" )
 
         String userName = "${namePrefix}user1"
-        print( "Creating user for IAM policy testing: ${userName}" )
+        print( "Creating USER for IAM policy testing: ${userName}" )
         String userId = createUser( new CreateUserRequest(
           userName: userName,
           path: '/'
         ) ).with {
           user?.userId
         }
-        print( "Created user with ID: ${userId}" )
+        print( "Created USER with ID: ${userId}" )
         cleanupTasks.add{
-          print( "Deleting user: ${userName}" )
+          print( "Deleting USER: ${userName}" )
           deleteUser( new DeleteUserRequest( userName: userName ) )
         }
 
         String policyName = "${namePrefix}policy1"
-        print( "Authorizing user for all actions on ${loadBalancerName1}" )
+        print( "Authorizing USER for all actions on ${loadBalancerName1}" )
         putUserPolicy( new PutUserPolicyRequest(
           userName: userName,
           policyName: policyName,
@@ -149,21 +149,21 @@ class TestELBIAMResource {
             """.stripMargin( ).trim( )
         ) )
         cleanupTasks.add{
-          print( "Deleting user ${userName} policy ${policyName}" )
+          print( "Deleting USER ${userName} policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest( userName: userName, policyName: policyName ) )
         }
         getUserPolicy( new GetUserPolicyRequest(  userName: userName, policyName: policyName ) ).with {
           print( policyDocument )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         userCredentials = createAccessKey( new CreateAccessKeyRequest( userName: userName ) ).with {
           accessKey?.with {
             new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
           }
         }
         cleanupTasks.add{
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -198,11 +198,11 @@ class TestELBIAMResource {
         }
       }
 
-//      print( "Waiting a while for user credentials to propagate .." )
+//      print( "Waiting a while for USER credentials to propagate .." )
 //      sleep( 30000 )
 
       getELBClient( userCredentials ).with {
-        print( "Adding tag to load balancer as user with specific resource permissions: ${loadBalancerName1}" )
+        print( "Adding tag to load balancer as USER with specific resource permissions: ${loadBalancerName1}" )
         addTags( new AddTagsRequest(
             loadBalancerNames: [ loadBalancerName1 ],
             tags: [
@@ -211,7 +211,7 @@ class TestELBIAMResource {
         ))
         print( "Added tag to ${loadBalancerName1}" )
 
-        print( "Adding tag to load balancer as user with specific resource permissions: ${loadBalancerName2}" )
+        print( "Adding tag to load balancer as USER with specific resource permissions: ${loadBalancerName2}" )
         try {
           addTags( new AddTagsRequest(
               loadBalancerNames: [ loadBalancerName2 ],

--- a/com/eucalyptus/tests/awssdk/TestELBTagging.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBTagging.groovy
@@ -14,7 +14,6 @@ import com.amazonaws.services.elasticloadbalancing.model.AddTagsRequest
 import com.amazonaws.services.elasticloadbalancing.model.CreateLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancing.model.DeleteLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
 import com.amazonaws.services.elasticloadbalancing.model.DescribeTagsRequest
 import com.amazonaws.services.elasticloadbalancing.model.Listener
 import com.amazonaws.services.elasticloadbalancing.model.RemoveTagsRequest
@@ -23,10 +22,10 @@ import com.amazonaws.services.elasticloadbalancing.model.TagKeyOnly
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static N4j.ACCESS_KEY
+import static N4j.CLC_IP
+import static N4j.SECRET_KEY
+import static N4j.minimalInit
 
 /**
  *
@@ -42,7 +41,7 @@ class TestELBTagging {
 
   public TestELBTagging( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestELBVPC.groovy
+++ b/com/eucalyptus/tests/awssdk/TestELBVPC.groovy
@@ -26,10 +26,10 @@ import com.amazonaws.services.elasticloadbalancing.model.*
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 /**
  *
  */
@@ -44,7 +44,7 @@ class TestELBVPC {
 
   public TestELBVPC(  ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestIAMInstanceProfileManagement.java
+++ b/com/eucalyptus/tests/awssdk/TestIAMInstanceProfileManagement.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests management of IAM instance profiles.

--- a/com/eucalyptus/tests/awssdk/TestIAMInstanceProfiles.java
+++ b/com/eucalyptus/tests/awssdk/TestIAMInstanceProfiles.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 
 /**

--- a/com/eucalyptus/tests/awssdk/TestIAMRoleManagement.java
+++ b/com/eucalyptus/tests/awssdk/TestIAMRoleManagement.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests management of IAM roles.

--- a/com/eucalyptus/tests/awssdk/TestMultipleSecurityGroups.groovy
+++ b/com/eucalyptus/tests/awssdk/TestMultipleSecurityGroups.groovy
@@ -5,7 +5,7 @@ import com.amazonaws.services.autoscaling.model.*
 import com.amazonaws.services.ec2.model.*
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*
+import static N4j.*
 
 /**
  * Test functionality for multiple (EC2-Classic) security groups.

--- a/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
+++ b/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
@@ -23,10 +23,10 @@ import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
 import org.testng.Assert
 import org.testng.annotations.Test
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * Tests IAM locationConstraint condition key for S3.
@@ -44,7 +44,7 @@ class TestS3IAMConditionKeyLocationConstraint {
 
   TestS3IAMConditionKeyLocationConstraint( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -126,7 +126,7 @@ class TestS3IAMConditionKeyLocationConstraint {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -140,8 +140,8 @@ class TestS3IAMConditionKeyLocationConstraint {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -155,19 +155,19 @@ class TestS3IAMConditionKeyLocationConstraint {
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -189,14 +189,14 @@ class TestS3IAMConditionKeyLocationConstraint {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -206,7 +206,7 @@ class TestS3IAMConditionKeyLocationConstraint {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId

--- a/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
+++ b/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
@@ -26,10 +26,10 @@ import org.testng.annotations.Test
 
 import java.nio.charset.StandardCharsets
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * Tests IAM versionId condition key for S3.
@@ -47,7 +47,7 @@ class TestS3IAMConditionKeyVersionId {
 
   TestS3IAMConditionKeyVersionId( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -113,7 +113,7 @@ class TestS3IAMConditionKeyVersionId {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -127,8 +127,8 @@ class TestS3IAMConditionKeyVersionId {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -181,19 +181,19 @@ class TestS3IAMConditionKeyVersionId {
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -226,14 +226,14 @@ class TestS3IAMConditionKeyVersionId {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -243,7 +243,7 @@ class TestS3IAMConditionKeyVersionId {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -266,7 +266,7 @@ class TestS3IAMConditionKeyVersionId {
 //          print( "Getting object foo version ${version1} from ${bucketName}, should fail" )
 //          getObject( new GetObjectRequest( bucketName, 'foo', version1 ) ).with {
 //            print( "Got object ${key}" )
-//            assertTrue( false, "Expected get object version to fail for user due to permissions" )
+//            assertTrue( false, "Expected get object version to fail for USER due to permissions" )
 //          }
 //        } catch ( AmazonServiceException e ) {
 //          print( "Expected error getting object version without permission: ${e}" )
@@ -276,7 +276,7 @@ class TestS3IAMConditionKeyVersionId {
 //          print( "Getting object foo ${version1} from ${bucketName}, should fail" )
 //          getObject( new GetObjectRequest( bucketName, 'foo' ) ).with {
 //            print( "Got object ${key}" )
-//            assertTrue( false, "Expected get object to fail for user due to permissions" )
+//            assertTrue( false, "Expected get object to fail for USER due to permissions" )
 //          }
 //        } catch ( AmazonServiceException e ) {
 //          print( "Expected error getting object without permission: ${e}" )
@@ -295,7 +295,7 @@ class TestS3IAMConditionKeyVersionId {
         try {
           print( "Deleting object foo version ${version1} from ${bucketName}, should fail" )
           deleteVersion( bucketName, 'foo', version1  );
-          assertTrue( false, "Expected delete object version to fail for user due to permissions" )
+          assertTrue( false, "Expected delete object version to fail for USER due to permissions" )
         } catch ( AmazonServiceException e ) {
           print( "Expected error deleting object version without permission: ${e}" )
         }

--- a/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
+++ b/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
@@ -30,10 +30,10 @@ import org.testng.annotations.Test
 
 import java.nio.charset.StandardCharsets
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+import static N4j.minimalInit
+import static N4j.CLC_IP
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
 
 /**
  * Tests IAM x-amz-acl and x-amz-grant-* condition keys for S3.
@@ -51,7 +51,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
 
   TestS3IAMConditionKeysForAclsAndGrants( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -117,7 +117,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -131,8 +131,8 @@ class TestS3IAMConditionKeysForAclsAndGrants {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -153,19 +153,19 @@ class TestS3IAMConditionKeysForAclsAndGrants {
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -208,14 +208,14 @@ class TestS3IAMConditionKeysForAclsAndGrants {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -225,7 +225,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -337,7 +337,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -351,8 +351,8 @@ class TestS3IAMConditionKeysForAclsAndGrants {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -403,26 +403,26 @@ class TestS3IAMConditionKeysForAclsAndGrants {
       String policyName = "${namePrefix}policy1"
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add {
-          println("Deleting user ${userName}")
+          println("Deleting USER ${userName}")
           deleteUser(new DeleteUserRequest(
               userName: userName
           ))
         }
-        print("Creating user ${userName}")
+        print("Creating USER ${userName}")
         createUser(new CreateUserRequest(
             userName: userName,
             path: '/'
         ))
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -432,7 +432,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -445,7 +445,7 @@ class TestS3IAMConditionKeysForAclsAndGrants {
       [ 'read', 'write', 'read-acp', 'write-acp', 'full-control' ].each { String permission ->
         String invalidPermission = permission == 'read' ? 'write' : 'read'
         getYouAreClient( adminCredentials ).with {
-          print( "Setting user policy ${policyName}" )
+          print( "Setting USER policy ${policyName}" )
           putUserPolicy( new PutUserPolicyRequest(
               userName: userName,
               policyName: policyName,

--- a/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
+++ b/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
@@ -23,10 +23,10 @@ import org.testng.annotations.Test
 
 import java.nio.charset.StandardCharsets
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+import static N4j.minimalInit
+import static N4j.CLC_IP
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
 
 /**
  * Tests IAM x-amz-copy-source and x-amz-metadata-directive condition keys for S3.
@@ -44,7 +44,7 @@ class TestS3IAMConditionKeysForPutObject {
 
   TestS3IAMConditionKeysForPutObject( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -110,7 +110,7 @@ class TestS3IAMConditionKeysForPutObject {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -124,8 +124,8 @@ class TestS3IAMConditionKeysForPutObject {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -154,19 +154,19 @@ class TestS3IAMConditionKeysForPutObject {
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -200,14 +200,14 @@ class TestS3IAMConditionKeysForPutObject {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -217,7 +217,7 @@ class TestS3IAMConditionKeysForPutObject {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId

--- a/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
+++ b/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
@@ -29,10 +29,10 @@ import org.testng.annotations.Test
 
 import java.nio.charset.StandardCharsets
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+import static N4j.minimalInit
+import static N4j.CLC_IP
+import static N4j.ACCESS_KEY
+import static N4j.SECRET_KEY
 
 /**
  * Tests IAM prefix and delimiter condition keys for S3.
@@ -54,7 +54,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
 
   TestS3IAMConditionKeysPrefixAndDelimiter( ) {
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 
@@ -120,7 +120,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -134,8 +134,8 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
@@ -185,19 +185,19 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -225,14 +225,14 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -242,7 +242,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -342,7 +342,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         }
 
         // Get credentials for admin account
-        print("Creating access key for test account admin user: ${accountName}")
+        print("Creating access key for test account admin USER: ${accountName}")
         YouAre adminIam = getYouAreClient( credentials )
         adminIam.addRequestHandler(new AbstractRequestHandler() {
           public void beforeRequest(final Request<?> request) {
@@ -356,27 +356,27 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
             }
           }
         }
-        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
-        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+        assertTrue(adminCredentials != null, "Expected test acount admin USER credentials")
+        print("Created test acount admin USER access key: ${adminCredentials.credentials.AWSAccessKeyId}")
 
         adminCredentials
       }
 
       AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
         cleanupTasks.add{
-          println( "Deleting user ${userName}" )
+          println( "Deleting USER ${userName}" )
           deleteUser( new DeleteUserRequest(
               userName: userName
           ) )
         }
-        print( "Creating user ${userName}" )
+        print( "Creating USER ${userName}" )
         createUser( new CreateUserRequest(
             userName: userName,
             path: '/'
         ) )
 
         String policyName = "${namePrefix}policy1"
-        print( "Creating user policy ${policyName}" )
+        print( "Creating USER policy ${policyName}" )
         putUserPolicy( new PutUserPolicyRequest(
             userName: userName,
             policyName: policyName,
@@ -416,14 +416,14 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         ) )
 
         cleanupTasks.add{
-          print( "Deleting user policy ${policyName}" )
+          print( "Deleting USER policy ${policyName}" )
           deleteUserPolicy( new DeleteUserPolicyRequest(
               userName: userName,
               policyName: policyName
           ) )
         }
 
-        print( "Creating access key for user ${userName}" )
+        print( "Creating access key for USER ${userName}" )
         AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
             userName: userName
         ) ).with {
@@ -433,7 +433,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         }
 
         cleanupTasks.add {
-          print( "Deleting access key for user ${userName}" )
+          print( "Deleting access key for USER ${userName}" )
           deleteAccessKey( new DeleteAccessKeyRequest(
               userName: userName,
               accessKeyId: userCredentials.credentials.AWSAccessKeyId
@@ -494,7 +494,7 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
         try {
           print( "Putting object to ${bucketName} outside of home directory, should fail" )
           putObject( bucketName, "foo1", new ByteArrayInputStream( "DATA".getBytes( "utf-8" ) ), new ObjectMetadata( ) );
-          assertThat( false, "Expected put object to fail for admin user due to permissions" )
+          assertThat( false, "Expected put object to fail for admin USER due to permissions" )
         } catch ( AmazonServiceException e ) {
           print( "Expected error putting object without permission: ${e}" )
         }

--- a/com/eucalyptus/tests/awssdk/TestSTSAssumeRole.java
+++ b/com/eucalyptus/tests/awssdk/TestSTSAssumeRole.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2013 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests assuming an IAM role using STS and consuming EC2 with the role.

--- a/com/eucalyptus/tests/awssdk/TestSTSGetAccessToken.java
+++ b/com/eucalyptus/tests/awssdk/TestSTSGetAccessToken.java
@@ -51,10 +51,10 @@ import com.github.sjones4.youcan.youtoken.model.GetAccessTokenResult;
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static com.eucalyptus.tests.awssdk.N4j.minimalInit;
+import static com.eucalyptus.tests.awssdk.N4j.CLC_IP;
+import static com.eucalyptus.tests.awssdk.N4j.ACCESS_KEY;
+import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
 
 /**
  * This application tests getting an access token using STS and consuming EC2 with the creds.
@@ -74,7 +74,7 @@ public class TestSTSGetAccessToken {
 
   public TestSTSGetAccessToken( ) throws Exception {
     minimalInit();
-    this.host = HOST_IP;
+    this.host = CLC_IP;
     this.accessKey = ACCESS_KEY;
     this.secretKey = SECRET_KEY;
   }

--- a/com/eucalyptus/tests/awssdk/TestSTSGetImpersonationToken.java
+++ b/com/eucalyptus/tests/awssdk/TestSTSGetImpersonationToken.java
@@ -48,10 +48,10 @@ import com.github.sjones4.youcan.youtoken.model.GetImpersonationTokenRequest;
 import com.github.sjones4.youcan.youtoken.model.GetImpersonationTokenResult;
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static com.eucalyptus.tests.awssdk.N4j.minimalInit;
+import static com.eucalyptus.tests.awssdk.N4j.CLC_IP;
+import static com.eucalyptus.tests.awssdk.N4j.ACCESS_KEY;
+import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
 /**
  * This application tests getting an impersonation token using STS and consuming EC2 with the creds.
  *
@@ -70,7 +70,7 @@ public class TestSTSGetImpersonationToken {
 
   public TestSTSGetImpersonationToken() throws Exception{
     minimalInit();
-    this.host = HOST_IP;
+    this.host = CLC_IP;
     this.accessKey = ACCESS_KEY;
     this.secretKey = SECRET_KEY;
   }

--- a/com/eucalyptus/tests/awssdk/TestSWFRegistration.groovy
+++ b/com/eucalyptus/tests/awssdk/TestSWFRegistration.groovy
@@ -25,10 +25,10 @@ import com.amazonaws.services.simpleworkflow.model.WorkflowType
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * This application tests registration actions for SWF.
@@ -49,7 +49,7 @@ class TestSWFRegistration {
 
   public TestSWFRegistration(){
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/com/eucalyptus/tests/awssdk/TestSWFSuccessWorkflow.groovy
+++ b/com/eucalyptus/tests/awssdk/TestSWFSuccessWorkflow.groovy
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit
 
 import org.testng.annotations.Test;
 
-import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
-import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
-import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+import static N4j.minimalInit;
+import static N4j.CLC_IP;
+import static N4j.ACCESS_KEY;
+import static N4j.SECRET_KEY;
 
 /**
  * This application tests SWF functionality for successful workflows.
@@ -35,7 +35,7 @@ class TestSWFSuccessWorkflow {
 
   public TestSWFSuccessWorkflow(){
     minimalInit()
-    this.host = HOST_IP
+    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
   }
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,6 +6,7 @@
         <!-- core dependencies -->
         <dependency org="log4j" name="log4j" rev="1.2.17"/>
         <dependency org="org.testng" name="testng" rev="6.8.5"/>
+        <dependency org="com.jcraft" name="jsch" rev="0.1.53"/>
         <dependency org="com.amazonaws" name="aws-java-sdk-autoscaling" rev="1.10.+"/>
         <dependency org="com.amazonaws" name="aws-java-sdk-cloudformation" rev="1.10.+"/>
         <dependency org="com.amazonaws" name="aws-java-sdk-cloudwatch" rev="1.10.+"/>


### PR DESCRIPTION
Instead of passing a eucarc file the setup now takes a CLC ip address. The test runner generates a set of cloud admin credentials (if creds created by the runner are not already present) and will retrieve that ini file. From this file endpoints and credential info is parsed.

There is a new basic test of functionality (N4jTest) that demonstrates getting cloud connection and cleaning up credentials after the test run.

Some testing was done to ensure existing tests are in working order but there are probably some that will still need to be updated for the changes.